### PR TITLE
Use pkg_resources's for `parse_requirements`

### DIFF
--- a/dist_utils.py
+++ b/dist_utils.py
@@ -16,7 +16,7 @@
 
 import os
 
-from pip.req import parse_requirements
+from pkg_resources import parse_requirements
 
 __all__ = [
     'fetch_requirements',


### PR DESCRIPTION
This has moved into a private module in `pip` as it comes from `setuptools`' `pkg_resources`. Thus we switch to source of truth.