### PR TITLE
Revert "Use pkg_resources's for `parse_requirements`"

### DIFF
--- a/dist_utils.py
+++ b/dist_utils.py
@@ -16,7 +16,7 @@
 
 import os
 
-from pkg_resources import parse_requirements
+from pip.req import parse_requirements
 
 __all__ = [
     'fetch_requirements',


### PR DESCRIPTION
Reverts dennybaa/circleci-helpers#5